### PR TITLE
feat: Reposicionar nueva-era-section con fondo blanco después de nav-grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -418,6 +418,85 @@
             transform: translateY(-2px);
         }
 
+        /* 🔄 Nueva Era Section - AHORA CON FONDO BLANCO */
+        .new-era-section {
+            padding: 8rem 2rem !important;
+            background: #ffffff !important;
+            background-color: #ffffff !important;
+            color: var(--primary-black) !important;
+        }
+
+        .new-era-container {
+            max-width: 1200px;
+            margin: 0 auto;
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 6rem;
+            align-items: center;
+        }
+
+        .new-era-content h2 {
+            font-size: 2.8rem !important;
+            font-weight: 300 !important;
+            margin-bottom: 2rem !important;
+            color: var(--primary-black) !important;
+            line-height: 1.2 !important;
+            letter-spacing: -1px !important;
+        }
+
+        .new-era-content h3 {
+            font-size: 1.8rem !important;
+            font-weight: 300 !important;
+            margin-bottom: 2rem !important;
+            color: var(--secondary-gray) !important;
+        }
+
+        .new-era-content p {
+            font-size: 1.2rem !important;
+            color: var(--secondary-gray) !important;
+            margin-bottom: 2rem !important;
+            line-height: 1.6 !important;
+        }
+
+        .new-era-technologies {
+            display: grid;
+            grid-template-columns: repeat(2, 1fr);
+            gap: 2rem;
+            margin-top: 3rem;
+        }
+
+        .tech-feature {
+            background: rgba(248, 248, 248, 1) !important;
+            padding: 2rem !important;
+            border-radius: 12px !important;
+            border: 1px solid rgba(0, 0, 0, 0.05) !important;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.03) !important;
+        }
+
+        .tech-feature h4 {
+            font-size: 1.1rem !important;
+            margin-bottom: 0.5rem !important;
+            font-weight: 600 !important;
+            color: var(--primary-black) !important;
+        }
+
+        .tech-feature p {
+            font-size: 0.9rem !important;
+            margin: 0 !important;
+            color: var(--secondary-gray) !important;
+            line-height: 1.5 !important;
+        }
+
+        .new-era-image {
+            height: 500px;
+            background: url('https://otfbouzmhmmguvqbbwku.supabase.co/storage/v1/object/public/imagenes-sitio/imagen_1755189383506_0.jpeg');
+            background-size: cover;
+            background-position: center;
+            border-radius: 16px !important;
+            border: 1px solid rgba(0, 0, 0, 0.05) !important;
+            box-shadow: 0 8px 24px rgba(0, 0, 0, 0.06) !important;
+        }
+
         /* 🚨 SECCIÓN PROPIEDADES - FONDO BLANCO TOTAL FORZADO */
         .properties-section {
             padding: 8rem 2rem !important;
@@ -926,78 +1005,6 @@
             color: white;
         }
 
-        /* Nueva Era Section */
-        .new-era-section {
-            padding: 8rem 2rem;
-            background: linear-gradient(var(--overlay-medium), var(--overlay-medium)), 
-                        url('https://images.unsplash.com/photo-1600607687939-ce8a6c25118c?w=1920&h=1080&fit=crop&crop=center');
-            background-size: cover;
-            background-position: center;
-            background-attachment: fixed;
-            color: white;
-        }
-
-        .new-era-container {
-            max-width: 1200px;
-            margin: 0 auto;
-            display: grid;
-            grid-template-columns: 1fr 1fr;
-            gap: 6rem;
-            align-items: center;
-        }
-
-        .new-era-content h2 {
-            font-size: 2.8rem;
-            font-weight: 300;
-            margin-bottom: 2rem;
-            color: white;
-            line-height: 1.2;
-            letter-spacing: -1px;
-        }
-
-        .new-era-content p {
-            font-size: 1.2rem;
-            color: rgba(255, 255, 255, 0.9);
-            margin-bottom: 2rem;
-            line-height: 1.6;
-        }
-
-        .new-era-technologies {
-            display: grid;
-            grid-template-columns: repeat(2, 1fr);
-            gap: 2rem;
-            margin-top: 3rem;
-        }
-
-        .tech-feature {
-            background: rgba(255, 255, 255, 0.1);
-            backdrop-filter: blur(20px);
-            padding: 2rem;
-            border: 1px solid rgba(255, 255, 255, 0.2);
-        }
-
-        .tech-feature h4 {
-            font-size: 1.1rem;
-            margin-bottom: 0.5rem;
-            font-weight: 600;
-            color: var(--elegant-black);
-        }
-
-        .tech-feature p {
-            font-size: 0.9rem;
-            margin: 0;
-            opacity: 0.8;
-        }
-
-        .new-era-image {
-            height: 500px;
-            background: linear-gradient(var(--overlay-light), var(--overlay-light)), 
-                        url('https://otfbouzmhmmguvqbbwku.supabase.co/storage/v1/object/public/imagenes-sitio/imagen_1755189383506_0.jpeg');
-            background-size: cover;
-            background-position: center;
-            border: 1px solid rgba(255, 255, 255, 0.2);
-        }
-
         /* Contact Section */
         .contact-section {
             padding: 8rem 2rem;
@@ -1231,7 +1238,6 @@
 
             .stats-section,
             .properties-section,
-            .new-era-section,
             .contact-section {
                 background-attachment: scroll;
             }
@@ -1375,6 +1381,38 @@
         </div>
     </section>
 
+    <!-- 🔄 Nueva Era Section - REPOSICIONADA CON FONDO BLANCO -->
+    <section class="new-era-section" id="redefiniendo">
+        <div class="new-era-container">
+            <div class="new-era-content fade-in">
+                <h2>La nueva era de lo inmobiliario comienza aquí</h2>
+                <h3 style="font-size: 1.8rem; font-weight: 300; margin-bottom: 2rem; color: var(--secondary-gray);">Revolucionando la manera de encontrar tu hogar</h3>
+                <p>Porque entendemos que la tarea de encontrar tu próximo hogar es difícil, ya que implica tiempo y recursos. Acá en Casa Nuvera te brindamos las mejores herramientas para adquirir la propiedad que anhelas.</p>
+                
+                <div class="new-era-technologies">
+                    <div class="tech-feature">
+                        <h4>Tour virtuales última generación</h4>
+                        <p>Recorre propiedades desde la comodidad de tu hogar con tecnología 360°</p>
+                    </div>
+                    <div class="tech-feature">
+                        <h4>IA aplicada al sector inmobiliario</h4>
+                        <p>Algoritmos inteligentes que encuentran la propiedad perfecta para ti</p>
+                    </div>
+                    <div class="tech-feature">
+                        <h4>Integración de tecnologías</h4>
+                        <p>En un mercado competitivo, aplicamos las mejores herramientas para facilitar la venta de tu propiedad.</p>
+                    </div>
+                    <div class="tech-feature">
+                        <h4>Plataforma digital</h4>
+                        <p>Gestiona todo el proceso de compra o venta desde nuestra plataforma</p>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="new-era-image fade-in"></div>
+        </div>
+    </section>
+
     <!-- Properties Section - PROPIEDADES REALES CON REDIRECCIÓN -->
     <section class="properties-section" id="propiedades">
         <div class="properties-container">
@@ -1500,38 +1538,6 @@
 
     <!-- Stats Section -->
     <section class="stats-section parallax"></section>
-
-    <!-- Nueva Era Section -->
-    <section class="new-era-section parallax" id="redefiniendo">
-        <div class="new-era-container">
-            <div class="new-era-content fade-in">
-                <h2>La nueva era de lo inmobiliario comienza aquí</h2>
-                <h3 style="font-size: 1.8rem; font-weight: 300; margin-bottom: 2rem; color: var(--elegant-black);">Revolucionando la manera de encontrar tu hogar</h3>
-                <p>Porque entendemos que la tarea de encontrar tu próximo hogar es difícil, ya que implica tiempo y recursos. Acá en Casa Nuvera te brindamos las mejores herramientas para adquirir la propiedad que anhelas.</p>
-                
-                <div class="new-era-technologies">
-                    <div class="tech-feature">
-                        <h4>Tour virtuales última generación</h4>
-                        <p>Recorre propiedades desde la comodidad de tu hogar con tecnología 360°</p>
-                    </div>
-                    <div class="tech-feature">
-                        <h4>IA aplicada al sector inmobiliario</h4>
-                        <p>Algoritmos inteligentes que encuentran la propiedad perfecta para ti</p>
-                    </div>
-                    <div class="tech-feature">
-                        <h4>Integración de tecnologías</h4>
-                        <p>En un mercado competitivo, aplicamos las mejores herramientas para facilitar la venta de tu propiedad.</p>
-                    </div>
-                    <div class="tech-feature">
-                        <h4>Plataforma digital</h4>
-                        <p>Gestiona todo el proceso de compra o venta desde nuestra plataforma</p>
-                    </div>
-                </div>
-            </div>
-            
-            <div class="new-era-image fade-in"></div>
-        </div>
-    </section>
 
     <!-- Contact Section -->
     <section class="contact-section parallax" id="contacto">


### PR DESCRIPTION
## 📋 Descripción de Cambios

Este PR reposiciona la sección "La nueva era de lo inmobiliario comienza aquí" para que aparezca inmediatamente después del navigation grid (4 cards) y le aplica fondo blanco para mantener consistencia visual.

## ✅ Cambios Realizados

### 1. **Reposicionamiento HTML**
- ✅ Movida `nueva-era-section` desde después de Stats Section
- ✅ Ahora aparece inmediatamente después del `nav-grid` (4 cards)
- ✅ Mantiene ID `#redefiniendo` para navegación

### 2. **Estilos CSS Actualizados**
- ✅ **Fondo blanco:** `background: #ffffff !important`
- ✅ **Texto negro:** `color: var(--primary-black) !important`  
- ✅ **Subtítulos grises:** `color: var(--secondary-gray) !important`
- ✅ **Tech-features:** Fondo gris claro `rgba(248, 248, 248, 1)` con sombras sutiles
- ✅ **Imagen lateral:** Mantiene imagen con bordes redondeados y sombra suave

### 3. **Orden Final de Secciones**
1. Hero Section
2. Navigation Grid (4 cards)  
3. **🔄 Nueva Era Section** ← REPOSICIONADA CON FONDO BLANCO
4. Properties Section
5. Gallery Section
6. Stats Section  
7. Contact Section
8. Footer

## 🎨 Resultado Visual
- Sección ahora tiene fondo blanco consistente con el resto del sitio
- Textos en negro/gris para óptimo contraste
- Tech-features con fondo gris claro para mejor legibilidad
- Posicionamiento estratégico después del nav-grid

## ⚠️ Notas Importantes
- ✅ **SIN cambios en funcionalidad**
- ✅ **SIN modificaciones en JavaScript**
- ✅ **SIN alteración de contenido**
- ✅ **Responsive design mantenido**

## 🧪 Testing Recomendado
- [ ] Verificar orden de secciones correcto
- [ ] Confirmar fondo blanco aplicado
- [ ] Revisar contraste de texto  
- [ ] Probar responsive en móvil