### PR TITLE
🔧 Fix: Remove property_id causing lead form error

### DIFF
--- a/js/lead-popup.js
+++ b/js/lead-popup.js
@@ -977,8 +977,7 @@ class LeadPopup {
             zona_interes: selectedZones.length > 0 ? selectedZones : null,
             mensaje: formData.get('mensaje'),
             
-            // Additional tracking data
-            property_id: this.currentProperty?.id || null,
+            // Additional tracking data (property_id removed - it's stored in property_favorites table)
             utm_source: this.getUrlParameter('utm_source'),
             utm_campaign: this.getUrlParameter('utm_campaign'),
             utm_medium: this.getUrlParameter('utm_medium'),


### PR DESCRIPTION
## 🔴 BUGFIX: Solucionar error en formulario de leads

### Problema
El formulario del sistema de leads estaba arrojando un **error 400** al intentar enviar los datos:
```
"Could not find the 'property_id' column of 'leads' in the schema cache"
```

### Causa raíz
El código JavaScript en `js/lead-popup.js` estaba enviando un campo `property_id` que **no existe** en la tabla `leads` de Supabase.

### Solución
- ✅ **Removido** el campo `property_id` del objeto `leadData` en la función `gatherFormData()`
- ✅ **Agregado** comentario explicativo sobre dónde se almacenan las asociaciones de propiedades
- ✅ **Mantenida** la funcionalidad: las asociaciones propiedad-lead se guardan correctamente en la tabla `property_favorites`

### Cambios específicos
```javascript
// ANTES - Causaba el error:
property_id: this.currentProperty?.id || null,

// DESPUÉS - Solucionado:
// Additional tracking data (property_id removed - it's stored in property_favorites table)
```

### Testing
Una vez mergeado este PR:
1. El formulario debería enviar sin errores
2. Los leads se guardarán correctamente en la tabla `leads`
3. Las asociaciones propiedad-favorito seguirán funcionando via `property_favorites`

### Archivos modificados
- `js/lead-popup.js`

---
**🎯 Este cambio solucionará completamente el error del formulario de leads**