### PR TITLE
Fix mobile search bar cutoff

### DIFF
--- a/index.html
+++ b/index.html
@@ -1349,13 +1349,25 @@
             }
 
             .search-filters {
-                grid-template-columns: 1fr;
+                grid-template-columns: 1fr !important;
+                gap: 0.75rem !important;
+                align-items: stretch !important;
             }
 
             /* Evitar zoom en iOS al enfocar (>=16px) */
             .search-select,
             .search-input {
                 font-size: 16px !important;
+                width: 100% !important;
+                min-width: 0 !important;
+            }
+
+            .search-btn {
+                width: 100% !important;
+            }
+
+            .property-search-bar {
+                padding: 1rem !important;
             }
 
             .properties-grid-container,


### PR DESCRIPTION
Fixes search bar cutoff on mobile by applying responsive CSS adjustments.

The search grid now collapses to a single column, and inputs/buttons use full width to prevent overflow on small screens.

---
<a href="https://cursor.com/background-agent?bcId=bc-6d433ffb-174f-43ca-acaf-0d07ba2237b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6d433ffb-174f-43ca-acaf-0d07ba2237b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

