### PR TITLE
Ajustar estilo de botón y valor UF

### DIFF
--- a/property-detail.html
+++ b/property-detail.html
@@ -1145,9 +1145,8 @@
                     <div class="contact-buttons">
                         <!-- 🆕 Contenedor Tour: selector + botón (visible solo si hay tours) -->
                         <select id="tourSelect" class="tour-select" style="display:none;"></select>
-                        <button id="sidebarTourBtn" class="tour-btn" style="display:none;">
-                            <span class="tour-icon">🔄</span>
-                            Ver Tour Virtual
+                        <button id="sidebarTourBtn" class="contact-btn whatsapp" style="display:none;">
+                            🔄 VER TOUR VIRTUAL
                         </button>
                         <a href="#" class="contact-btn whatsapp" onclick="contactViaWhatsApp(); return false;">
                             📱 CONTACTAR POR WHATSAPP
@@ -1182,7 +1181,7 @@
 
     <!-- 🆕 Sticky CTA móvil -->
     <div class="sticky-cta" id="stickyCta" style="display:none;">
-        <a href="#" class="cta-btn secondary" id="stickyTourBtn" style="display:none;" onclick="openSelectedTour(); return false;">Tour</a>
+        <a href="#" class="cta-btn primary" id="stickyTourBtn" style="display:none;" onclick="openSelectedTour(); return false;">Tour</a>
         <a href="#" class="cta-btn primary" onclick="contactViaWhatsApp(); return false;">WhatsApp</a>
         <a href="tel:+56948406684" class="cta-btn secondary">Llamar</a>
     </div>


### PR DESCRIPTION
Update "Ver Tour Virtual" buttons to match WhatsApp button styling.

The sidebar "Ver Tour Virtual" button and the mobile sticky "Tour" button now adopt the same size, text style, and appearance as the "Contactar por WhatsApp" button for visual consistency.

---
<a href="https://cursor.com/background-agent?bcId=bc-8b816e74-b1b0-49dd-8c7f-b1ec9fe723cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8b816e74-b1b0-49dd-8c7f-b1ec9fe723cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

