### PR TITLE
Fix property image and video display

### DIFF
--- a/arriendos.html
+++ b/arriendos.html
@@ -557,7 +557,7 @@
         }
 
         function goToProperty(propertyId) {
-            window.location.href = `propiedad.html?id=${propertyId}`;
+            window.location.href = `property-detail.html?id=${propertyId}`;
         }
 
         function showLoading(show) {

--- a/compras-nuevo.html
+++ b/compras-nuevo.html
@@ -1090,7 +1090,7 @@
         // Funciones de interacción
         function goToProperty(id) {
             console.log(`Navegando a propiedad ${id}`);
-            window.location.href = `propiedad.html?id=${id}`;
+            window.location.href = `property-detail.html?id=${id}`;
         }
 
         function contactProperty(id) {

--- a/form-scripts-fixed.js
+++ b/form-scripts-fixed.js
@@ -713,12 +713,21 @@ async function loadPropertyForEdit(propertyId) {
         updateTourOrder();
 
         // Cargar imágenes existentes (solo mostrar)
-        const { data: images } = await window.supabase
-            .from('property_images')
-            .select('id, image_url, image_order, is_main')
-            .eq('property_id', propertyId)
-            .order('image_order', { ascending: true });
-        renderExistingImages(images || []);
+        let images = [];
+        try {
+            const { data: imgs } = await window.supabase
+                .from('property_images')
+                .select('id, image_url, image_order, is_main')
+                .eq('property_id', propertyId)
+                .order('image_order', { ascending: true });
+            images = imgs || [];
+        } catch (_) { images = []; }
+
+        // Fallback: si no hay filas en property_images pero la propiedad tiene image_url, mostrarla editable
+        if ((!images || images.length === 0) && property.image_url) {
+            images = [{ id: null, image_url: property.image_url, image_order: 0, is_main: true }];
+        }
+        renderExistingImages(images);
 
         // Cargar videos existentes (solo mostrar, no editar orden/títulos desde aquí aún)
         try {

--- a/index-nuevo.html
+++ b/index-nuevo.html
@@ -804,7 +804,7 @@
         // Funciones globales
         window.goToProperty = function(propertyId) {
             console.log('🔗 Navegando a propiedad:', propertyId);
-            window.location.href = `propiedad.html?id=${propertyId}`;
+            window.location.href = `property-detail.html?id=${propertyId}`;
         };
 
         window.contactProperty = function(propertyId) {

--- a/property-loader.js
+++ b/property-loader.js
@@ -398,7 +398,7 @@ window.goToProperty = function(propertyId) {
     try {
         console.log('🔗 Navegando a propiedad:', propertyId);
         // Navegar a la página de detalle
-        window.location.href = `propiedad.html?id=${propertyId}`;
+window.location.href = `property-detail.html?id=${propertyId}`;
     } catch (error) {
         console.error('❌ Error navegando a propiedad:', error);
         alert('Error al abrir la propiedad. Por favor, intenta nuevamente.');


### PR DESCRIPTION
Display property's main image in editor for deletion and ensure videos appear on detail page.

The main `image_url` is now shown in the property editor with a delete option when no `property_images` are present, and navigation to `property-detail.html` is unified to correctly display videos.

---
<a href="https://cursor.com/background-agent?bcId=bc-63e5701a-2785-49cc-b3e1-e85857dbeebe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-63e5701a-2785-49cc-b3e1-e85857dbeebe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

