### PR TITLE
Add built square meters to property page

### DIFF
--- a/property-detail.html
+++ b/property-detail.html
@@ -1153,6 +1153,10 @@
                                 <span>260m² totales</span>
                             </div>
                             <div class="feature-item">
+                                <span class="feature-icon">🏗️</span>
+                                <span>180m² construidos</span>
+                            </div>
+                            <div class="feature-item">
                                 <span class="feature-icon">🛏️</span>
                                 <span>3 dormitorios</span>
                             </div>
@@ -1199,6 +1203,10 @@
                         <div class="sidebar-feature">
                             <span class="sidebar-feature-label">Superficie total</span>
                             <span class="sidebar-feature-value">260 m²</span>
+                        </div>
+                        <div class="sidebar-feature">
+                            <span class="sidebar-feature-label">Metros construidos</span>
+                            <span class="sidebar-feature-value">180 m²</span>
                         </div>
                         <div class="sidebar-feature">
                             <span class="sidebar-feature-label">Dormitorios</span>


### PR DESCRIPTION
Add display for built square meters (`metros construidos`) on the property detail page, both below the images and in the sidebar.

---
<a href="https://cursor.com/background-agent?bcId=bc-f202120b-dced-4cf2-8056-c6f8b0148592"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f202120b-dced-4cf2-8056-c6f8b0148592"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

