### PR TITLE
Cambiar color de espacios en blanco a rojo

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,6 +41,9 @@
             --charcoal: #36454F;
             --light-gray-accent: #D3D3D3;
             --dark-gray: #2F2F2F;
+            
+            /* Color rojo para texto que debe ser rojo */
+            --red-accent: #dc3545;
         }
 
         /* Toggle de navegación (oculto por defecto en desktop) */
@@ -1479,6 +1482,23 @@
         /* Refuerzo en móviles: deshabilitar parallax fijo */
         @media (max-width: 768px) {
             .parallax { background-attachment: scroll !important; }
+        }
+
+        /* REGLAS PARA CAMBIAR TEXTO BLANCO A ROJO */
+        .text-white-to-red,
+        .white-text-red {
+            color: var(--red-accent) !important;
+        }
+
+        /* Regla específica para texto entre imagen y contenido */
+        .image-text-red {
+            color: var(--red-accent) !important;
+        }
+
+        /* Regla para texto que debe ser rojo como el fondo de despacho y soporte 24/7 */
+        .despacho-soporte-text {
+            color: var(--red-accent) !important;
+            font-weight: 600;
         }
     </style>
 </head>

--- a/property-styles.css
+++ b/property-styles.css
@@ -5,6 +5,18 @@
     --green-accent: #333333; /* Cambio de verde a gris oscuro */
     --black-accent: #000000;
     --dark-gray: #333333;
+    --red-accent: #dc3545; /* Color rojo para texto que debe ser rojo */
+}
+
+/* REGLA PARA CAMBIAR TEXTO BLANCO A ROJO */
+.text-white-to-red,
+.white-text-red {
+    color: var(--red-accent) !important;
+}
+
+/* Regla específica para texto entre imagen y contenido */
+.image-text-red {
+    color: var(--red-accent) !important;
 }
 
 /* Properties Grid - Diseño compacto y oscuro */


### PR DESCRIPTION
Add CSS utility classes to style white text in red, matching the 'despacho y soporte 24/7' background color.

Since the specific white text location could not be identified, general utility classes were introduced for manual application.

---
<a href="https://cursor.com/background-agent?bcId=bc-7482fcd7-1142-4516-a3e8-e9d77c479684"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7482fcd7-1142-4516-a3e8-e9d77c479684"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

