### PR TITLE
Fix video upload not appearing on property page

### DIFF
--- a/SOLUCION-VIDEOS.md
+++ b/SOLUCION-VIDEOS.md
@@ -1,0 +1,59 @@
+# Solución para Problema de Subida de Videos
+
+## Problema Identificado
+El error `StorageApiError: new row violates row-level security policy` indica que las políticas de seguridad de Supabase están bloqueando la subida de videos. Esto ocurre tanto en el Storage bucket como en la tabla `property_videos`.
+
+## Solución
+
+### Paso 1: Ejecutar Script SQL en Supabase
+1. Ve a tu proyecto de Supabase
+2. Abre el **SQL Editor**
+3. Copia y pega el contenido completo del archivo `supabase_video_complete_fix.sql`
+4. Ejecuta el script
+
+### Paso 2: Verificar Configuración Manual (si es necesario)
+Si el script automático no funciona, configura manualmente:
+
+#### En Storage:
+1. Ve a **Storage** > **Buckets**
+2. Crea un nuevo bucket llamado `property-videos`
+3. Marca como **Público**
+4. Establece límite de archivo a 50MB
+5. Agrega tipos MIME permitidos: `video/mp4`, `video/avi`, `video/mov`, `video/webm`, `video/mkv`
+
+#### En Policies:
+1. Ve a **Authentication** > **Policies**
+2. Busca la tabla `property_videos`
+3. Crea las siguientes políticas:
+   - **SELECT**: `true`
+   - **INSERT**: `true`
+   - **UPDATE**: `true`
+   - **DELETE**: `true`
+
+### Paso 3: Verificar que Funciona
+1. Intenta subir un video en tu aplicación
+2. Revisa la consola del navegador
+3. Deberías ver mensajes de éxito en lugar del error de RLS
+
+## Archivos Creados
+- `supabase_video_complete_fix.sql` - Script completo para ejecutar
+- `supabase_video_storage_fix.sql` - Solo correcciones de Storage
+- `supabase_video_table_fix.sql` - Solo correcciones de tabla
+
+## ¿Por qué Ocurrió Este Problema?
+1. **RLS Habilitado**: Supabase tiene Row Level Security habilitado por defecto
+2. **Políticas Faltantes**: No había políticas configuradas para permitir operaciones en `property_videos`
+3. **Bucket Sin Configurar**: El bucket `property-videos` no tenía políticas de Storage configuradas
+
+## Verificación Post-Solución
+Después de ejecutar el script, deberías poder:
+- ✅ Subir videos sin errores de RLS
+- ✅ Ver videos en la página de propiedades
+- ✅ Eliminar videos correctamente
+- ✅ Editar propiedades con videos
+
+## Si Aún Hay Problemas
+1. Verifica que el bucket `property-videos` existe y es público
+2. Revisa que las políticas RLS están activas
+3. Comprueba que el usuario tiene permisos de autenticación
+4. Revisa los logs de Supabase para errores específicos

--- a/supabase_video_complete_fix.sql
+++ b/supabase_video_complete_fix.sql
@@ -1,0 +1,202 @@
+-- Script SQL COMPLETO para corregir problemas de videos en Supabase
+-- Ejecutar en SQL Editor de Supabase
+-- Este script corrige tanto Storage como la tabla property_videos
+
+-- ========================================
+-- PARTE 1: CONFIGURAR TABLA property_videos
+-- ========================================
+
+-- 1. Crear tabla property_videos si no existe
+CREATE TABLE IF NOT EXISTS public.property_videos (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    property_id uuid NOT NULL REFERENCES public.properties(id) ON DELETE CASCADE,
+    video_url text NOT NULL,
+    video_title text,
+    video_order int DEFAULT 1,
+    created_at timestamp with time zone DEFAULT now()
+);
+
+-- 2. Habilitar RLS en property_videos
+ALTER TABLE public.property_videos ENABLE ROW LEVEL SECURITY;
+
+-- 3. Crear políticas RLS para property_videos
+-- Política para permitir lectura
+DO $$ 
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies 
+        WHERE schemaname = 'public' 
+        AND tablename = 'property_videos' 
+        AND policyname = 'Allow read property_videos'
+    ) THEN
+        CREATE POLICY "Allow read property_videos" ON public.property_videos 
+        FOR SELECT USING (true);
+        RAISE NOTICE 'Política de lectura creada para property_videos';
+    END IF;
+END $$;
+
+-- Política para permitir inserción
+DO $$ 
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies 
+        WHERE schemaname = 'public' 
+        AND tablename = 'property_videos' 
+        AND policyname = 'Allow insert property_videos'
+    ) THEN
+        CREATE POLICY "Allow insert property_videos" ON public.property_videos 
+        FOR INSERT WITH CHECK (true);
+        RAISE NOTICE 'Política de inserción creada para property_videos';
+    END IF;
+END $$;
+
+-- Política para permitir actualización
+DO $$ 
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies 
+        WHERE schemaname = 'public' 
+        AND tablename = 'property_videos' 
+        AND policyname = 'Allow update property_videos'
+    ) THEN
+        CREATE POLICY "Allow update property_videos" ON public.property_videos 
+        FOR UPDATE USING (true);
+        RAISE NOTICE 'Política de actualización creada para property_videos';
+    END IF;
+END $$;
+
+-- Política para permitir eliminación
+DO $$ 
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies 
+        WHERE schemaname = 'public' 
+        AND tablename = 'property_videos' 
+        AND policyname = 'Allow delete property_videos'
+    ) THEN
+        CREATE POLICY "Allow delete property_videos" ON public.property_videos 
+        FOR DELETE USING (true);
+        RAISE NOTICE 'Política de eliminación creada para property_videos';
+    END IF;
+END $$;
+
+-- 4. Configurar REPLICA IDENTITY para property_videos
+ALTER TABLE public.property_videos REPLICA IDENTITY FULL;
+
+-- ========================================
+-- PARTE 2: CONFIGURAR STORAGE BUCKET
+-- ========================================
+
+-- 5. Crear bucket property-videos si no existe
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES (
+    'property-videos',
+    'property-videos',
+    true,
+    52428800, -- 50MB limit
+    ARRAY['video/mp4', 'video/avi', 'video/mov', 'video/webm', 'video/mkv']
+) ON CONFLICT (id) DO NOTHING;
+
+-- 6. Crear políticas de Storage para el bucket property-videos
+-- Política para permitir lectura pública de videos
+INSERT INTO storage.policies (id, bucket_id, name, definition, check_expression, command)
+VALUES (
+    'property-videos-read-policy',
+    'property-videos',
+    'Permitir lectura pública de videos',
+    'true',
+    'true',
+    'SELECT'
+) ON CONFLICT (id) DO NOTHING;
+
+-- Política para permitir subida de videos
+INSERT INTO storage.policies (id, bucket_id, name, definition, check_expression, command)
+VALUES (
+    'property-videos-upload-policy',
+    'property-videos',
+    'Permitir subida de videos',
+    'true',
+    'true',
+    'INSERT'
+) ON CONFLICT (id) DO NOTHING;
+
+-- Política para permitir actualización de videos
+INSERT INTO storage.policies (id, bucket_id, name, definition, check_expression, command)
+VALUES (
+    'property-videos-update-policy',
+    'property-videos',
+    'Permitir actualización de videos',
+    'true',
+    'true',
+    'UPDATE'
+) ON CONFLICT (id) DO NOTHING;
+
+-- Política para permitir eliminación de videos
+INSERT INTO storage.policies (id, bucket_id, name, definition, check_expression, command)
+VALUES (
+    'property-videos-delete-policy',
+    'property-videos',
+    'Permitir eliminación de videos',
+    'true',
+    'true',
+    'DELETE'
+) ON CONFLICT (id) DO NOTHING;
+
+-- ========================================
+-- PARTE 3: FUNCIONES AUXILIARES
+-- ========================================
+
+-- 7. Crear función RPC para eliminar videos de propiedad
+CREATE OR REPLACE FUNCTION delete_property_videos(property_id UUID)
+RETURNS void AS $$
+BEGIN
+    DELETE FROM property_videos WHERE property_videos.property_id = delete_property_videos.property_id;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- ========================================
+-- PARTE 4: VERIFICACIÓN FINAL
+-- ========================================
+
+-- 8. Verificar configuración de la tabla
+SELECT 
+    'Tabla property_videos' as component,
+    COUNT(*) as policies_count
+FROM pg_policies 
+WHERE tablename = 'property_videos';
+
+-- 9. Verificar configuración del bucket
+SELECT 
+    'Bucket property-videos' as component,
+    b.name as bucket_name,
+    b.public as is_public,
+    COUNT(p.id) as policies_count
+FROM storage.buckets b
+LEFT JOIN storage.policies p ON p.bucket_id = b.id
+WHERE b.name = 'property-videos'
+GROUP BY b.name, b.public;
+
+-- 10. Verificar estructura de la tabla
+SELECT 
+    'Estructura de tabla' as component,
+    column_name, 
+    data_type, 
+    is_nullable
+FROM information_schema.columns 
+WHERE table_name = 'property_videos' 
+AND table_schema = 'public'
+ORDER BY ordinal_position;
+
+-- 11. Verificar funciones RPC
+SELECT 
+    'Funciones RPC' as component,
+    routine_name, 
+    routine_type 
+FROM information_schema.routines 
+WHERE routine_name = 'delete_property_videos'
+AND routine_schema = 'public';
+
+-- ========================================
+-- MENSAJE FINAL
+-- ========================================
+SELECT '✅ Configuración de videos completada exitosamente' as status;

--- a/supabase_video_storage_fix.sql
+++ b/supabase_video_storage_fix.sql
@@ -1,0 +1,109 @@
+-- Script SQL para corregir políticas de Supabase Storage para videos
+-- Ejecutar en SQL Editor de Supabase
+
+-- 1. Crear bucket property-videos si no existe (esto debe hacerse manualmente en el panel de Supabase)
+-- Storage > Buckets > New bucket > name: property-videos > Public: enabled
+
+-- 2. Crear políticas de Storage para el bucket property-videos
+-- Estas políticas permiten subir, leer y eliminar videos
+
+-- Política para permitir lectura pública de videos
+INSERT INTO storage.policies (id, bucket_id, name, definition, check_expression, command)
+VALUES (
+    'property-videos-read-policy',
+    'property-videos',
+    'Permitir lectura pública de videos',
+    'true',
+    'true',
+    'SELECT'
+) ON CONFLICT (id) DO NOTHING;
+
+-- Política para permitir subida de videos
+INSERT INTO storage.policies (id, bucket_id, name, definition, check_expression, command)
+VALUES (
+    'property-videos-upload-policy',
+    'property-videos',
+    'Permitir subida de videos',
+    'true',
+    'true',
+    'INSERT'
+) ON CONFLICT (id) DO NOTHING;
+
+-- Política para permitir actualización de videos
+INSERT INTO storage.policies (id, bucket_id, name, definition, check_expression, command)
+VALUES (
+    'property-videos-update-policy',
+    'property-videos',
+    'Permitir actualización de videos',
+    'true',
+    'true',
+    'UPDATE'
+) ON CONFLICT (id) DO NOTHING;
+
+-- Política para permitir eliminación de videos
+INSERT INTO storage.policies (id, bucket_id, name, definition, check_expression, command)
+VALUES (
+    'property-videos-delete-policy',
+    'property-videos',
+    'Permitir eliminación de videos',
+    'true',
+    'true',
+    'DELETE'
+) ON CONFLICT (id) DO NOTHING;
+
+-- 3. Verificar que las políticas se crearon correctamente
+SELECT 
+    id,
+    bucket_id,
+    name,
+    definition,
+    check_expression,
+    command
+FROM storage.policies 
+WHERE bucket_id = 'property-videos'
+ORDER BY command;
+
+-- 4. Verificar que el bucket existe y está configurado correctamente
+SELECT 
+    id,
+    name,
+    public,
+    file_size_limit,
+    allowed_mime_types
+FROM storage.buckets 
+WHERE name = 'property-videos';
+
+-- 5. Si el bucket no existe, crear una función para crearlo
+-- (Nota: Esto normalmente se hace desde el panel de Supabase)
+CREATE OR REPLACE FUNCTION create_property_videos_bucket()
+RETURNS void AS $$
+BEGIN
+    -- Intentar crear el bucket (esto puede fallar si ya existe)
+    INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+    VALUES (
+        'property-videos',
+        'property-videos',
+        true,
+        52428800, -- 50MB limit
+        ARRAY['video/mp4', 'video/avi', 'video/mov', 'video/webm', 'video/mkv']
+    );
+EXCEPTION
+    WHEN unique_violation THEN
+        -- El bucket ya existe, no hacer nada
+        RAISE NOTICE 'Bucket property-videos ya existe';
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- 6. Ejecutar la función para crear el bucket si no existe
+SELECT create_property_videos_bucket();
+
+-- 7. Verificar configuración final
+SELECT 
+    'Bucket configurado' as status,
+    b.name as bucket_name,
+    b.public as is_public,
+    COUNT(p.id) as policy_count
+FROM storage.buckets b
+LEFT JOIN storage.policies p ON p.bucket_id = b.id
+WHERE b.name = 'property-videos'
+GROUP BY b.name, b.public;

--- a/supabase_video_table_fix.sql
+++ b/supabase_video_table_fix.sql
@@ -1,0 +1,130 @@
+-- Script SQL para corregir políticas de la tabla property_videos
+-- Ejecutar en SQL Editor de Supabase
+
+-- 1. Verificar si la tabla property_videos existe y tiene RLS habilitado
+SELECT 
+    schemaname, 
+    tablename, 
+    rowsecurity as rls_enabled
+FROM pg_tables t
+JOIN pg_class c ON c.relname = t.tablename
+WHERE tablename = 'property_videos';
+
+-- 2. Verificar políticas existentes en property_videos
+SELECT 
+    schemaname, 
+    tablename, 
+    policyname, 
+    permissive, 
+    roles, 
+    cmd, 
+    qual 
+FROM pg_policies 
+WHERE tablename = 'property_videos'
+ORDER BY policyname;
+
+-- 3. Crear políticas RLS para property_videos si no existen
+-- Política para permitir lectura
+DO $$ 
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies 
+        WHERE schemaname = 'public' 
+        AND tablename = 'property_videos' 
+        AND policyname = 'Allow read property_videos'
+    ) THEN
+        CREATE POLICY "Allow read property_videos" ON public.property_videos 
+        FOR SELECT USING (true);
+        RAISE NOTICE 'Política de lectura creada para property_videos';
+    ELSE
+        RAISE NOTICE 'Política de lectura ya existe para property_videos';
+    END IF;
+END $$;
+
+-- Política para permitir inserción
+DO $$ 
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies 
+        WHERE schemaname = 'public' 
+        AND tablename = 'property_videos' 
+        AND policyname = 'Allow insert property_videos'
+    ) THEN
+        CREATE POLICY "Allow insert property_videos" ON public.property_videos 
+        FOR INSERT WITH CHECK (true);
+        RAISE NOTICE 'Política de inserción creada para property_videos';
+    ELSE
+        RAISE NOTICE 'Política de inserción ya existe para property_videos';
+    END IF;
+END $$;
+
+-- Política para permitir actualización
+DO $$ 
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies 
+        WHERE schemaname = 'public' 
+        AND tablename = 'property_videos' 
+        AND policyname = 'Allow update property_videos'
+    ) THEN
+        CREATE POLICY "Allow update property_videos" ON public.property_videos 
+        FOR UPDATE USING (true);
+        RAISE NOTICE 'Política de actualización creada para property_videos';
+    ELSE
+        RAISE NOTICE 'Política de actualización ya existe para property_videos';
+    END IF;
+END $$;
+
+-- Política para permitir eliminación
+DO $$ 
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies 
+        WHERE schemaname = 'public' 
+        AND tablename = 'property_videos' 
+        AND policyname = 'Allow delete property_videos'
+    ) THEN
+        CREATE POLICY "Allow delete property_videos" ON public.property_videos 
+        FOR DELETE USING (true);
+        RAISE NOTICE 'Política de eliminación creada para property_videos';
+    ELSE
+        RAISE NOTICE 'Política de eliminación ya existe para property_videos';
+    END IF;
+END $$;
+
+-- 4. Configurar REPLICA IDENTITY para property_videos
+ALTER TABLE public.property_videos REPLICA IDENTITY FULL;
+
+-- 5. Verificar configuración final
+SELECT 
+    'property_videos configurado' as status,
+    COUNT(*) as total_policies
+FROM pg_policies 
+WHERE tablename = 'property_videos';
+
+-- 6. Verificar estructura de la tabla
+SELECT 
+    column_name, 
+    data_type, 
+    is_nullable, 
+    column_default 
+FROM information_schema.columns 
+WHERE table_name = 'property_videos' 
+AND table_schema = 'public'
+ORDER BY ordinal_position;
+
+-- 7. Crear función RPC para eliminar videos de propiedad (método alternativo)
+CREATE OR REPLACE FUNCTION delete_property_videos(property_id UUID)
+RETURNS void AS $$
+BEGIN
+    DELETE FROM property_videos WHERE property_videos.property_id = delete_property_videos.property_id;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- 8. Verificar que la función se creó correctamente
+SELECT 
+    routine_name, 
+    routine_type 
+FROM information_schema.routines 
+WHERE routine_name = 'delete_property_videos'
+AND routine_schema = 'public';


### PR DESCRIPTION
Adds Supabase RLS policies and storage bucket configuration to enable video uploads and display on property pages.

The previous setup lacked necessary Row Level Security policies for the `property_videos` table and the `property-videos` storage bucket, causing `StorageApiError: new row violates row-level security policy` and preventing videos from being saved and displayed. This PR provides SQL scripts to correctly configure these policies.

---
<a href="https://cursor.com/background-agent?bcId=bc-f39f136e-60b6-4de8-89df-b2b523b8b7c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f39f136e-60b6-4de8-89df-b2b523b8b7c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

