### PR TITLE
Fix save slide button in gallery management

### DIFF
--- a/admin-gallery.html
+++ b/admin-gallery.html
@@ -1157,6 +1157,11 @@
                 document.getElementById('modalTitle').textContent = 'Agregar Nuevo Slide';
                 document.getElementById('slideType').value = type;
                 document.getElementById('slideFile').accept = type === 'image' ? 'image/*' : 'video/*';
+                // En modo agregar, el archivo debe ser requerido
+                const fileInputAdd = document.getElementById('slideFile');
+                if (fileInputAdd) {
+                    fileInputAdd.required = true;
+                }
                 document.getElementById('slideForm').reset();
                 document.getElementById('fileInputLabel').textContent = '📁 Seleccionar archivo';
                 document.getElementById('fileInputLabel').classList.remove('has-file');
@@ -1174,6 +1179,11 @@
                 document.getElementById('slideType').value = slide.type;
                 document.getElementById('slideOrder').value = slide.order;
                 document.getElementById('slideFile').accept = slide.type === 'image' ? 'image/*' : 'video/*';
+                // En modo edición, no exigimos subir un archivo nuevo
+                const fileInputEdit = document.getElementById('slideFile');
+                if (fileInputEdit) {
+                    fileInputEdit.required = false;
+                }
                 document.getElementById('fileInputLabel').textContent = '📁 Archivo actual (sin cambios)';
                 document.getElementById('fileInputLabel').classList.add('has-file');
                 document.getElementById('slideModal').style.display = 'block';


### PR DESCRIPTION
Adjust `required` attribute for slide file input to fix "Guardar Slide" button when editing.

Previously, the file input was always marked as `required`, which prevented the form from submitting when editing an existing slide without uploading a new file. This change ensures the file input is only required when adding a new slide, allowing edits to be saved correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-66c8b056-2b56-4041-919e-2bf3e2fcfac8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-66c8b056-2b56-4041-919e-2bf3e2fcfac8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

